### PR TITLE
chore(version): update version to v1.1.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.kroger.payments
-version = 1.0.0
+version = v1.1.1-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.daemon=true


### PR DESCRIPTION
## Description
This PR updates the version in gradle.properties to v1.1.1-SNAPSHOT after tag v1.1.1 was created.

## Changes
- Updated version from previous value to v1.1.1-SNAPSHOT
- This change prepares the codebase for the next development cycle

## Reason
After releasing version v1.1.1, we need to update the development version to reflect the next SNAPSHOT version.

Automated PR created by GitHub Actions after tag creation.